### PR TITLE
sponsors as posts

### DIFF
--- a/sponsors.md
+++ b/sponsors.md
@@ -7,3 +7,54 @@ permalink: /sponsors/
   <p>If you are interested in being a sponsor for KYCC-WiC, please contact Cindy Tucker, <a href="mailto:cindy.tucker@kctcs.edu">cindy.tucker@kctcs.edu</a>, or Melanie Williamson, <a href="mailto:melanie.williamson@kctcs.edu">melanie.williamson@kctcs.edu</a>.
   </p>
 </div>
+
+<div class="row">
+  <div class="col-md-12">
+  
+    <h3>Platinum Level - $2500</h3>
+    <ul>
+    {% for post in site.categories.sponsors reversed %}
+      {% if post.level contains "platinum" %}
+        <li>{{ post.title }}</li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+    
+    <h3>Gold Level - $1000</h3>
+    <ul>
+    {% for post in site.categories.sponsors reversed %}
+      {% if post.level contains "gold" %}
+        <li>{{ post.title }}</li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+    
+    <h3>Silver Level - $500</h3>
+    <ul>
+    {% for post in site.categories.sponsors reversed %}
+      {% if post.level contains "silver" %}
+        <li>{{ post.title }}</li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+    
+    <h3>Bronze Level - $250</h3>
+    <ul>
+    {% for post in site.categories.sponsors reversed %}
+      {% if post.level contains "bronze" %}
+        <li>{{ post.title }}</li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+    
+    <h3>Friends of the Conference - up to $250</h3>
+    <ul>
+    {% for post in site.categories.sponsors reversed %}
+      {% if post.level contains "friend" %}
+        <li>{{ post.title }}</li>
+      {% endif %}
+    {% endfor %}
+    </ul>
+    
+  </div>
+</div>

--- a/sponsors/_posts/2015-01-01-acm.md
+++ b/sponsors/_posts/2015-01-01-acm.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: ACM
+level: platinum
+---

--- a/sponsors/_posts/2015-01-02-microsoft.md
+++ b/sponsors/_posts/2015-01-02-microsoft.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: Micrsoft
+level: platinum
+---

--- a/sponsors/_posts/2015-01-03-qxnet.md
+++ b/sponsors/_posts/2015-01-03-qxnet.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: QX.net
+level: friend
+---

--- a/sponsors/_posts/2015-01-04-raytheon.md
+++ b/sponsors/_posts/2015-01-04-raytheon.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: Raytheon
+level: silver
+---

--- a/sponsors/_posts/2015-01-05-wic_students.md
+++ b/sponsors/_posts/2015-01-05-wic_students.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: Bluegrass Women in Computing Student Group
+level: friend
+---


### PR DESCRIPTION
Added sponsors as posts (the same as members on lexladiescode.org).

This way, our client will be able to easily add more sponsors.
